### PR TITLE
Update schedule hash calculation

### DIFF
--- a/src/gtfs/command/ApplyOverlays.ts
+++ b/src/gtfs/command/ApplyOverlays.ts
@@ -14,8 +14,9 @@ export function applyOverlays(schedules: OverlayRecord[], idGenerator: IdGenerat
       // get any schedules that share the same TUID
       for (const baseSchedule of schedulesByTuid[schedule.tuid] || []) {
         // remove the underlying schedule and add the replacement(s)
+        let replacements = applyOverlay(baseSchedule, schedule, idGenerator);
         schedulesByTuid[schedule.tuid].splice(
-          schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...applyOverlay(baseSchedule, schedule, idGenerator)
+          schedulesByTuid[schedule.tuid].indexOf(baseSchedule), 1, ...replacements
         );
       }
     }

--- a/src/gtfs/native/Schedule.ts
+++ b/src/gtfs/native/Schedule.ts
@@ -35,7 +35,14 @@ export class Schedule implements OverlayRecord {
   }
 
   public get hash(): string {
-    return this.tuid + this.stopTimes.map(s => s.stop_id + s.departure_time + s.arrival_time).join("") + this.calendar.binaryDays;
+    return this.tuid + 
+    this.stopTimes.map(s => 
+      s.stop_id + 
+      s.departure_time + 
+      s.arrival_time + 
+      s.pickup_type + 
+      s.drop_off_type)
+      .join("") + this.calendar.binaryDays;
   }
 
   /**


### PR DESCRIPTION
Add pick up and drop off to the train hash calculation. This is due to
the rare case where a train overlay may have the _exact_ same timings as
the base schedule as well as the same day mask (binary mask of which
days of the week the train runs), but have different passenger activities.