### PR TITLE
WIP: Add a short term fix to stop streaming zips from being created

### DIFF
--- a/config/gtfs/agency.ts
+++ b/config/gtfs/agency.ts
@@ -32,6 +32,7 @@ export const agencies: Agency[] = [
 { agency_id: "TW", agency_name: "Nexus (Tyne & Wear Metro)",  agency_url: "https://www.nexus.org.uk/metro",          agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0191 20 20 747", agency_fare_url: null },
 { agency_id: "CS", agency_name: "Serco Caledonian Sleeper",   agency_url: "https://www.sleeper.scot/",               agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0330 060 0500",  agency_fare_url: null },
 { agency_id: "XR", agency_name: "Crossrail",                  agency_url: "https://www.nationalrail.co.uk/",         agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "08457 48 49 50", agency_fare_url: null },
+{ agency_id: "QC", agency_name: "Caledonian MacBrayne",       agency_url: "https://www.calmac.co.uk/",               agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "0800 0665000",   agency_fare_url: null },
 { agency_id: "QS", agency_name: "Stena Line",                 agency_url: "https://www.google.com",                  agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "",               agency_fare_url: null },
 { agency_id: "ZZ", agency_name: "Other operator",             agency_url: "https://www.google.com",                  agency_timezone: "Europe/London", agency_lang: "en", agency_phone: "",               agency_fare_url: null },
 ];

--- a/src/cli/Container.ts
+++ b/src/cli/Container.ts
@@ -21,6 +21,7 @@ import {downloadUrl} from "../../config/nfm64";
 import {DownloadFileCommand} from "./DownloadFileCommand";
 import {PromiseSFTP} from "../sftp/PromiseSFTP";
 import {WebServerCommand} from "./WebServerCommand";
+import moment = require("moment");
 
 export class Container {
   @memoize
@@ -150,8 +151,8 @@ export class Container {
   private async getOutputGTFSCommand(): Promise<OutputGTFSCommand> {
     return this.getOutputGTFSCommandWithOutput(
       new FileOutput(),
-      new Date(new Date().setMonth(new Date().getMonth() - 3)),
-      new Date(new Date().setMonth(new Date().getMonth() + 1))
+      moment(new Date().setMonth(new Date().getMonth() - 3)).subtract(1, 'days'),
+      moment(new Date().setMonth(new Date().getMonth() + 1)).subtract(1, 'days')
     );
   }
 

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -41,7 +41,6 @@ export class OutputGTFSCommand implements CLICommand {
     const scheduleResultsP:Promise<ScheduleResults> = this.repository.getSchedules();
     const transfersP:Promise<void> = this.copy(this.repository.getTransfers(), "transfers.txt");
     const stopsP:Promise<void> = this.copy(this.repository.getStops(), "stops.txt");
-    const agencyP:Promise<void> = this.copy(agencies, "agency.txt");
     const fixedLinksP:Promise<void> = this.copy(this.repository.getFixedLinks(), "links.txt");
     
     const schedules:Schedule[] = this.getSchedules(await associationsP, await scheduleResultsP);
@@ -50,6 +49,7 @@ export class OutputGTFSCommand implements CLICommand {
     const calendarP:Promise<void> = this.copy(calendars, "calendar.txt");
     const calendarDatesP:Promise<void> = this.copy(calendarDates, "calendar_dates.txt");
     const tripsP:Promise<void> = this.copyTrips(schedules, serviceIds);
+    const agencyP:Promise<void> = this.copy(agencies, "agency.txt");
 
     await Promise.all([
       agencyP,
@@ -98,8 +98,24 @@ export class OutputGTFSCommand implements CLICommand {
       schedule.stopTimes.forEach(r => stopTimes.write(r));
     }
 
+    let knownAgencies: string[] = agencies.map(agency => agency.agency_id);
     for (const route of Object.values(routes)) {
       routeFile.write(route);
+
+      // In case we have new agency in the routes that doesn't exist in our agencies list, we create the agency with default info.
+      if (!knownAgencies.includes(route['agency_id'])) {
+        const createdAgency = {
+          agency_id: route['agency_id'],
+          agency_name: `${route['agency_id']} operator`,
+          agency_url: "https://www.google.com",
+          agency_timezone: "Europe/London",
+          agency_lang: "en",
+          agency_phone: "",
+          agency_fare_url: null
+        };
+        agencies.splice(-1, 0, createdAgency);
+        knownAgencies.push(route['agency_id']);
+      }
     }
 
     trips.end();

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -115,7 +115,7 @@ export class OutputGTFSCommand implements CLICommand {
     console.log("schedule overlays: ", scheduleResults.schedules.length);
     const processedSchedules = <ScheduleIndex>applyOverlays(scheduleResults.schedules, scheduleResults.idGenerator);
     const associatedSchedules = applyAssociations(processedSchedules, processedAssociations, scheduleResults.idGenerator);
-    console.log("merge schedules", associatedSchedules.length)
+    console.log("merge schedules", Object.keys(associatedSchedules).length)
     const mergedSchedules = <Schedule[]>mergeSchedules(associatedSchedules);
     const schedules = addLateNightServices(mergedSchedules, scheduleResults.idGenerator);
 

--- a/src/cli/OutputGTFSCommand.ts
+++ b/src/cli/OutputGTFSCommand.ts
@@ -11,9 +11,13 @@ import {ScheduleResults} from "../gtfs/repository/ScheduleBuilder";
 import {GTFSOutput} from "../gtfs/output/GTFSOutput";
 import * as fs from "fs";
 import {addLateNightServices} from "../gtfs/command/AddLateNightServices";
-import streamToPromise = require("stream-to-promise");
 import {Calendar} from "../gtfs/file/Calendar";
 import {CalendarDate} from "../gtfs/file/CalendarDate";
+
+const util = require('util');
+const stream = require('stream');
+const finished = util.promisify(stream.finished);
+
 
 export class OutputGTFSCommand implements CLICommand {
   public baseDir: string;
@@ -71,7 +75,7 @@ export class OutputGTFSCommand implements CLICommand {
     rows.forEach(row => output.write(row));
     output.end();
 
-    return streamToPromise(output);
+    return finished(output);
   }
 
   /**
@@ -103,9 +107,9 @@ export class OutputGTFSCommand implements CLICommand {
     routeFile.end();
 
     return Promise.all([
-      streamToPromise(trips),
-      streamToPromise(stopTimes),
-      streamToPromise(routeFile),
+      finished(trips),
+      finished(stopTimes),
+      finished(routeFile),
     ]);
   }
 

--- a/src/cli/WebServerCommand.ts
+++ b/src/cli/WebServerCommand.ts
@@ -15,6 +15,12 @@ export class WebServerCommand implements CLICommand {
     private gtfsCommandSupplier: (startRange, endRange, excludeFixedLinks, excludeVstpSchedules) => OutputGTFSCommand
   ) {}
 
+    waitForSeconds(seconds) {
+      return new Promise((res) => {
+        setTimeout(res, seconds * 1000)
+      })
+    }
+
   async run(argv: string[]) {
     if (!(argv[3] && argv[4])) {
       console.log(
@@ -57,6 +63,8 @@ export class WebServerCommand implements CLICommand {
         await gtfsCommand.run(argv);
         let baseDir = gtfsCommand.baseDir;
         // const archive = archiver("zip", {zlib: {level: 9}});
+        // Mega-bodge until I figure out when the underlying node event `finish` is called, and figure out when the file descriptor is released
+        await this.waitForSeconds(10);
 
         execSync(`zip -j tmp.zip ${baseDir}/*.txt`);
         // temporarily use the linux built-in zip, rather than doing it in node

--- a/src/cli/WebServerCommand.ts
+++ b/src/cli/WebServerCommand.ts
@@ -58,12 +58,12 @@ export class WebServerCommand implements CLICommand {
         let baseDir = gtfsCommand.baseDir;
         // const archive = archiver("zip", {zlib: {level: 9}});
 
-        execSync(`zip -j ${fileName} ${baseDir}/*.txt`);
+        execSync(`zip -j tmp.zip ${baseDir}/*.txt`);
         // temporarily use the linux built-in zip, rather than doing it in node
         // This is due to the fact that `gtfs-stream` library that Raptor uses breaks on a streamed zip, if the compressed data contains 
         // a certain set of characters
 
-        const passthrough = fs.createReadStream(fileName);
+        const passthrough = fs.createReadStream("tmp.zip");
         passthrough.on("data", () => {
           res.writeProcessing();
         });
@@ -90,7 +90,7 @@ export class WebServerCommand implements CLICommand {
               });
             }
           });
-          fs.unlinkSync(fileName);
+          fs.unlinkSync("tmp.zip");
           inProgress = false;
         });
       } else {

--- a/src/gtfs/native/Association.ts
+++ b/src/gtfs/native/Association.ts
@@ -56,20 +56,25 @@ export class Association implements OverlayRecord {
     // if the associated train starts running before the association, clone the associated schedule for those dates
     if (assoc.calendar.runsFrom.isBefore(assocCalendar.runsFrom)) {
       const before = assoc.calendar.clone(assoc.calendar.runsFrom, assocCalendar.runsFrom.clone().subtract(1, "days"));
-
-      schedules.push(assoc.clone(before, idGenerator.next().value));
+      if (before.runsFrom.isSameOrBefore(before.runsTo)) {
+        schedules.push(assoc.clone(before, idGenerator.next().value));
+      }
     }
 
     // if the associated train runs after the association has finished, clone the associated schedule for those dates
     if (assoc.calendar.runsTo.isAfter(assocCalendar.runsTo)) {
       const after = assoc.calendar.clone(assocCalendar.runsTo.clone().add(1, "days"), assoc.calendar.runsTo);
-
-      schedules.push(assoc.clone(after, idGenerator.next().value));
+      if(after.runsFrom.isSameOrBefore(after.runsTo)) {
+        schedules.push(assoc.clone(after, idGenerator.next().value));
+      }
     }
 
     // for each exclude day of the association
     for (const excludeDay of Object.values(assocCalendar.excludeDays)) {
-      schedules.push(assoc.clone(assoc.calendar.clone(excludeDay, excludeDay), idGenerator.next().value));
+      const excluded = assoc.calendar.clone(excludeDay, excludeDay);
+      if(excluded.runsFrom.isSameOrBefore(excluded.runsTo)) {
+        schedules.push(assoc.clone(excluded, idGenerator.next().value));
+      }
     }
 
     return schedules;

--- a/src/gtfs/native/ScheduleCalendar.ts
+++ b/src/gtfs/native/ScheduleCalendar.ts
@@ -102,7 +102,8 @@ export class ScheduleCalendar {
   }
 
   /**
-   * Remove the given days from the calendar then tighten the dates
+   * Remove the given days from the calendar then tighten the dates.
+   * Beware that this method might generate ScheduleCalendar with runsFrom > runsTo date.
    */
   public clone(start: Moment,
                end: Moment,

--- a/src/gtfs/repository/ScheduleBuilder.ts
+++ b/src/gtfs/repository/ScheduleBuilder.ts
@@ -118,8 +118,20 @@ export class ScheduleBuilder {
       unadvertisedDeparture = true;
     }
 
-    const activities = row.activity.match(/.{1,2}/g) || [];
+  //  There are some occurances of schedules that have malformed activities, such as `TBT` which are redundant, so we replace them with sane versions
+    let activities = row.activity.match(/.{1,2}/g) || [];
+    if (row.activity.includes("TBT")) {
+      row.activity = row.activity.replace("TBT", "TB");
+      activities = row.activity.match(/.{1,2}/g) || [];
+    }
+
+    if (row.activity.includes("TFT")) {
+      row.activity = row.activity.replace("TFT", "TF");
+      activities = row.activity.match(/.{1,2}/g) || [];
+    }
+
     const pickup = pickupActivities.find(a => activities.includes(a)) && !activities.includes(notAdvertised) && !unadvertisedDeparture ? 0 : 1;
+
     const coordinatedDropOff = coordinatedActivity.find(a => activities.includes(a)) ? 3 : 0;
     const dropOff = dropOffActivities.find(a => activities.includes(a)) && !unadvertisedArrival ? 0 : 1;
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
-
 import {Container} from "./cli/Container";
 
 const container = new Container();
 
 container
   .getCommand(process.argv[2])
-  .then(c => c.run(process.argv))
+  .then(c => {
+    console.log(new Date());
+    return c.run(process.argv);
+  })
+  .then(x => console.log(new Date()))
   .catch(console.error);


### PR DESCRIPTION
This is very much a bodge to stop the errors happening from streaming the zip files into Raptor.

I'm going to open a pull request that reverts this change as soon as this is merged, as fixing the `gtfs-stream`  is the more robust solution.